### PR TITLE
Fix date type error in db queries

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -47,7 +47,7 @@ export async function saveSubscriber(subscriber: Subscriber): Promise<Subscriber
   try {
     // Generate unsubscribe token if not provided
     const unsubscribeToken = subscriber.unsubscribeToken || generateUnsubscribeToken();
-    const consentDate = subscriber.marketingConsent ? new Date() : null;
+    const consentDate = subscriber.marketingConsent ? new Date().toISOString() : null;
 
     // Insert or update on conflict (duplicate email)
     const result = await sql`


### PR DESCRIPTION
Convert `consentDate` to an ISO string to fix a TypeScript error during Vercel deployment.

The `@vercel/postgres` library requires primitive types for SQL query parameters, and a `Date` object is not considered primitive, leading to a type mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c7662eb-f1e9-43e2-bbc8-6ddfd641d0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c7662eb-f1e9-43e2-bbc8-6ddfd641d0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

